### PR TITLE
allow exclusion of required stac fields

### DIFF
--- a/stac_api/api/app.py
+++ b/stac_api/api/app.py
@@ -58,7 +58,7 @@ def create_app(settings: ApiSettings) -> FastAPI:
         )
         app.include_router(create_tiles_router(), prefix="/titiler", tags=["Titiler"])
 
-    config_openapi(app)
+    config_openapi(app, settings)
 
     @app.on_event("startup")
     async def on_startup():

--- a/stac_api/api/routers.py
+++ b/stac_api/api/routers.py
@@ -17,7 +17,7 @@ from stac_api.api.models import (
 )
 from stac_api.api.routes import create_endpoint_from_model, create_endpoint_with_depends
 from stac_api.clients.base import BaseCoreClient, BaseTransactionsClient
-from stac_api.config import ApiSettings
+from stac_api.config import ApiExtensions, ApiSettings
 from stac_api.models import schemas
 from stac_pydantic import ItemCollection
 from stac_pydantic.api import ConformanceClasses, LandingPage
@@ -83,7 +83,9 @@ def create_core_router(client: BaseCoreClient, settings: ApiSettings) -> APIRout
     router.add_api_route(
         name="Search",
         path="/search",
-        response_model=ItemCollection,
+        response_model=None
+        if settings.api_extension_is_enabled(ApiExtensions.fields)
+        else ItemCollection,
         response_model_exclude_unset=True,
         response_model_exclude_none=True,
         methods=["POST"],
@@ -92,7 +94,9 @@ def create_core_router(client: BaseCoreClient, settings: ApiSettings) -> APIRout
     router.add_api_route(
         name="Search",
         path="/search",
-        response_model=ItemCollection,
+        response_model=None
+        if settings.api_extension_is_enabled(ApiExtensions.fields)
+        else ItemCollection,
         response_model_exclude_unset=True,
         response_model_exclude_none=True,
         methods=["GET"],

--- a/stac_api/clients/base.py
+++ b/stac_api/clients/base.py
@@ -2,7 +2,7 @@
 import abc
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from stac_api.models import schemas
 from stac_pydantic import ItemCollection
@@ -67,7 +67,7 @@ class BaseCoreClient(abc.ABC):
     @abc.abstractmethod
     def post_search(
         self, search_request: schemas.STACSearch, **kwargs
-    ) -> ItemCollection:
+    ) -> Dict[str, Any]:
         """search for items"""
         ...
 
@@ -84,7 +84,7 @@ class BaseCoreClient(abc.ABC):
         fields: Optional[List[str]] = None,
         sortby: Optional[str] = None,
         **kwargs
-    ) -> ItemCollection:
+    ) -> Dict[str, Any]:
         """GET search catalog"""
         ...
 

--- a/stac_api/clients/postgres/core.py
+++ b/stac_api/clients/postgres/core.py
@@ -415,7 +415,11 @@ class CoreCrudClient(PostgresClient, BaseCoreClient):
             xvals += [item_model.bbox[0], item_model.bbox[2]]
             yvals += [item_model.bbox[1], item_model.bbox[3]]
             response_features.append(item_model.to_dict(**filter_kwargs))
-        bbox = (min(xvals), min(yvals), max(xvals), max(yvals))
+
+        try:
+            bbox = (min(xvals), min(yvals), max(xvals), max(yvals))
+        except ValueError:
+            bbox = None
 
         context_obj = None
         if config.settings.api_extension_is_enabled(ApiExtensions.context):

--- a/stac_api/models/schemas.py
+++ b/stac_api/models/schemas.py
@@ -134,9 +134,7 @@ class FieldsExtension(FieldsBase):
             )
         return {
             "include": self._get_field_dict(include),
-            "exclude": self._get_field_dict(
-                self.exclude - config.settings.default_includes
-            ),
+            "exclude": self._get_field_dict(self.exclude),
         }
 
 

--- a/stac_api/openapi.py
+++ b/stac_api/openapi.py
@@ -2,17 +2,29 @@
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 
+from stac_api.config import ApiExtensions, ApiSettings
 
-def config_openapi(app: FastAPI):
+
+def config_openapi(app: FastAPI, settings: ApiSettings):
     """config openapi"""
 
     def custom_openapi():
         """config openapi"""
         if app.openapi_schema:
             return app.openapi_schema
+
         openapi_schema = get_openapi(
             title="Arturo STAC API", version="0.1", routes=app.routes
         )
+
+        if settings.api_extension_is_enabled(ApiExtensions.fields):
+            openapi_schema["paths"]["/search"]["get"]["responses"]["200"]["content"][
+                "application/json"
+            ]["schema"] = {"$ref": "#/components/schemas/ItemCollection"}
+            openapi_schema["paths"]["/search"]["post"]["responses"]["200"]["content"][
+                "application/json"
+            ]["schema"] = {"$ref": "#/components/schemas/ItemCollection"}
+
         app.openapi_schema = openapi_schema
         return app.openapi_schema
 

--- a/tests/resources/test_item.py
+++ b/tests/resources/test_item.py
@@ -679,7 +679,7 @@ def test_field_extension_exclude_default_includes(app_client, load_test_data):
 
     resp = app_client.post("/search", json=body)
     resp_json = resp.json()
-    assert "geometry" in resp_json["features"][0]
+    assert "geometry" not in resp_json["features"][0]
 
 
 def test_search_intersects_and_bbox(app_client):


### PR DESCRIPTION
Closes #18 @vincentsarago 

Removes the `/search` response model if the fields extension is enabled, allowing required stac fields to be excluded from the response.  Individual items are validated before field exclusion so I think this is fine.

```
$ curl --request POST 'localhost:8080/search' \
--data-raw '{
    "fields": {
        "exclude": ["geometry", "properties", "assets", "links", "type", "bbox"]
    }
}'

{
    "type": "FeatureCollection",
    "context": {
        "returned": 10,
        "limit": 10,
        "matched": 30
    },
    "features": [
        {
            "id": "047ab5f0-dce1-4166-a00d-425a3dbefe02"
        },
        {
            "id": "145fa700-16d4-4d34-98e0-7540d5c0885f"
        },
        {
            "id": "29c53e17-d7d1-4394-a80f-36763c8f42dc"
        },
        {
            "id": "386dfa13-c2b4-4ce6-8e6f-fcac73f4e64e"
        },
        {
            "id": "4610c58e-39f4-4d9d-94ba-ceddbf9ac570"
        },
        {
            "id": "4d8a8e40-d089-4ca7-92c8-27d810ee07bf"
        },
        {
            "id": "57f88dd2-e4e0-48e6-a2b6-7282d4ab8ea4"
        },
        {
            "id": "68f2c2b2-4bce-4c40-9a0d-782c1be1f4f2"
        },
        {
            "id": "70cc6c05-9fe0-436a-a264-a52515f3f242"
        },
        {
            "id": "85f923a5-a81f-4acd-bc7f-96c7c915f357"
        }
    ],
    "links": [
        {
            "href": "http://localhost:8080/search",
            "rel": "next",
            "type": "application/geo+json",
            "title": null,
            "label:assets": null,
            "method": "POST",
            "body": {
                "token": "qlieb1uO"
            },
            "merge": true
        }
    ],
    "bbox": [
        -94.6334839,
        37.0332547,
        -94.4329834,
        37.1055746
    ]
}
```

