### PR TITLE
add router middleware deco

### DIFF
--- a/stac_api/api/middleware.py
+++ b/stac_api/api/middleware.py
@@ -1,0 +1,34 @@
+"""api middleware"""
+
+from typing import Callable
+
+from fastapi import APIRouter, FastAPI
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.routing import Match
+
+
+def router_middleware(app: FastAPI, router: APIRouter):
+    """
+    Decorator to add a middleware which will only execute on routes attached to the specified router.  Assumes the
+    router has no prefix.
+    """
+
+    def deco(func: Callable) -> Callable:
+        async def _middleware(request: Request, call_next):
+            # Check if scopes match
+            matches = any(
+                [
+                    route.matches(request.scope)[0] == Match.FULL
+                    for route in router.routes
+                ]
+            )
+            if matches:  # Run the middleware if they do
+                return await func(request, call_next)
+            else:  # Otherwise skip the middleware
+                return await call_next(request)
+
+        app.add_middleware(BaseHTTPMiddleware, dispatch=_middleware)
+        return func
+
+    return deco


### PR DESCRIPTION
Adds decorator which applies a middleware to a specific router, since the routers are organized in a similar structure to the spec, this makes it easy to do, for example:
- Add authentication to transactions endpoints.
- Implement cloudfront signing for assets in read endpoints (/search, /collections/{collectionsId}/items/{itemId} etc.).