### PR TITLE
add cloudfront signing

### DIFF
--- a/stac_api/clients/cloudfront/__init__.py
+++ b/stac_api/clients/cloudfront/__init__.py
@@ -1,0 +1,2 @@
+"""clients.cloudfront"""
+from .cloudfront import Signer  # noqa

--- a/stac_api/clients/cloudfront/cloudfront.py
+++ b/stac_api/clients/cloudfront/cloudfront.py
@@ -1,0 +1,26 @@
+"""cloudfront"""
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+
+from botocore.signers import CloudFrontSigner
+
+
+@dataclass
+class Signer:
+    """creates cloudfront signed urls"""
+
+    cloudfront_domain: str
+    signer: CloudFrontSigner
+
+    def __call__(self, path: str, ttl: Optional[int] = 2628000):
+        """
+        :param path: path to sign
+        :param ttl: expiration (in seconds -- defaults to 1 month)
+        """
+        url = f"https://{self.cloudfront_domain}{path}"
+        expire_date = datetime.utcnow() + timedelta(seconds=ttl)
+        signed_url = self.signer.generate_presigned_url(
+            url=url, date_less_than=expire_date
+        )
+        return signed_url


### PR DESCRIPTION
- Add an extension which makes STAC core routes return asset href's as cloudfront signed URLs.