### PR TITLE
change datetime field to use timestamptz (#100)

### DIFF
--- a/alembic/versions/77c019af60bf_use_timestamptz_rather_than_timestamp.py
+++ b/alembic/versions/77c019af60bf_use_timestamptz_rather_than_timestamp.py
@@ -1,0 +1,40 @@
+"""use timestamptz rather than timestamp
+
+Revision ID: 77c019af60bf
+Revises: 131aab4d9e49
+Create Date: 2021-03-02 11:51:43.539119
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "77c019af60bf"
+down_revision = "131aab4d9e49"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """upgrade to this revision"""
+    op.execute(
+        """
+        ALTER TABLE
+            data.items
+            ALTER COLUMN datetime
+            TYPE timestamptz
+        ;
+    """
+    )
+
+
+def downgrade():
+    """downgrade from this revision"""
+    op.execute(
+        """
+        ALTER TABLE
+            data.items
+            ALTER COLUMN datetime
+            TYPE timestamp
+        ;
+    """
+    )

--- a/stac_api/config.py
+++ b/stac_api/config.py
@@ -43,6 +43,7 @@ class ApiSettings(BaseSettings):
 
     environment: str
     debug: bool = False
+    default_includes: Set[str] = None
 
     # Fields which are defined by STAC but not included in the database model
     forbidden_fields: Set[str] = {"type"}

--- a/stac_api/models/database.py
+++ b/stac_api/models/database.py
@@ -85,7 +85,7 @@ class Item(BaseModel):  # type:ignore
         sa.VARCHAR(1024), sa.ForeignKey(Collection.id), nullable=False
     )
     parent_collection = sa.orm.relationship("Collection", back_populates="children")
-    datetime = sa.Column(sa.TIMESTAMP, nullable=False)
+    datetime = sa.Column(sa.TIMESTAMP(timezone=True), nullable=False)
     links = sa.Column(JSONB)
 
     @classmethod


### PR DESCRIPTION
Changes items.datetime field to use timestamp with timezone Fixes #100 